### PR TITLE
Save cup host to database

### DIFF
--- a/cup_manager/active.py
+++ b/cup_manager/active.py
@@ -312,6 +312,8 @@ class ActiveCupManager:
 		save_cup_name = self.cup_name
 		save_key_name = self.cup_key_name
 		save_edition = self.cup_edition_num
+		save_host_login = self.cup_host.login if self.cup_host else ''
+		save_host_nickname = self.cup_host.nickname if self.cup_host else ''
 		if not self.cup_name:
 			save_cup_name = 'Cup'
 			# Use a silly key name so we never get overlap on the edition lookup for anonymous cups
@@ -322,7 +324,9 @@ class ActiveCupManager:
 				CupInfo.update(
 					cup_key=save_key_name,
 					cup_name=save_cup_name,
-					cup_edition=save_edition
+					cup_edition=save_edition,
+					cup_host_login=save_host_login,
+					cup_host_nickname=save_host_nickname
 				).where(
 					CupInfo.cup_start_time == self.cup_start_time
 				)
@@ -334,7 +338,9 @@ class ActiveCupManager:
 					cup_start_time=self.cup_start_time,
 					cup_key=save_key_name,
 					cup_name=save_cup_name,
-					cup_edition=save_edition
+					cup_edition=save_edition,
+					cup_host_login=save_host_login,
+					cup_host_nickname=save_host_nickname
 				)
 			)
 		await self._invalidate_view_cache_cup_info()

--- a/cup_manager/migrations/000_add_cup_host.py
+++ b/cup_manager/migrations/000_add_cup_host.py
@@ -1,0 +1,20 @@
+import logging
+from peewee import *
+from playhouse.migrate import migrate, SchemaMigrator
+
+from ..models.cup_model import CupInfo
+
+logger = logging.getLogger(__name__)
+
+
+def upgrade(migrator: SchemaMigrator) -> None:
+	cup_host_login = CharField(max_length=150, null=True)
+	cup_host_nickname = CharField(max_length=150, null=True)
+	migrate(
+		migrator.add_column(CupInfo._meta.db_table, 'cup_host_login', cup_host_login),
+		migrator.add_column(CupInfo._meta.db_table, 'cup_host_nickname', cup_host_nickname)
+	)
+
+
+def downgrade(migrator: SchemaMigrator) -> None:
+	pass

--- a/cup_manager/models/cup_model.py
+++ b/cup_manager/models/cup_model.py
@@ -23,6 +23,16 @@ class CupInfo(TimedModel):
 	Edition number of the cup
 	"""
 
+	cup_host_login = CharField(max_length=150, null=True)
+	"""
+	Login of the cup host for this edition
+	"""
+
+	cup_host_nickname = CharField(max_length=150, null=True)
+	"""
+	Nickname of the cup host for this edition
+	"""
+
 	class Meta:
 		db_table = 'cup_manager_cupinfo_v1'
 

--- a/cup_manager/views/cup_view.py
+++ b/cup_manager/views/cup_view.py
@@ -40,6 +40,14 @@ class CupView(ManualListView):
 				'type': 'label',
 			},
 			{
+				'name': 'Host',
+				'index': 'host_str',
+				'sorting': True,
+				'searching': True,
+				'width': 40,
+				'type': 'label',
+			},
+			{
 				'name': 'Date',
 				'index': 'cup_start_time_str',
 				'sorting': True,
@@ -52,7 +60,7 @@ class CupView(ManualListView):
 				'index': 'maps_str',
 				'sorting': True,
 				'searching': True,
-				'width': 30,
+				'width': 20,
 				'type': 'label',
 			},
 		]
@@ -70,6 +78,7 @@ class CupView(ManualListView):
 				'cup_edition': f'Edition #{str(cup_data.cup_edition)}',
 				'cup_start_time_str': datetime.fromtimestamp(cup_data.cup_start_time).strftime("%c"),
 				'maps_str': str(len(map_start_times)),
+				'host_str': str(cup_data.cup_host_nickname if cup_data.cup_host_nickname else ''),
 				# For row reference
 				'cup_start_time': cup_data.cup_start_time,
 			})


### PR DESCRIPTION
This change saves the cup host information to the database so it can be browsed from the `//cup cups` command