### PR TITLE
Decode downloaded json response as string

### DIFF
--- a/skybaks/cup_manager/config.py
+++ b/skybaks/cup_manager/config.py
@@ -251,7 +251,7 @@ class CupConfiguration:
                 logger.error(f"Got invalid response from download url {url}")
                 return
             out_filename = await self.get_filename_from_url(url)
-            await self.write_file_from_config_dir(out_filename, await response.read())
+            await self.write_file_from_config_dir(out_filename, (await response.read()).decode("utf-8"))
         except Exception as e:
             logger.error(f'Exception while trying to download from "{url}": {str(e)}')
             if player:


### PR DESCRIPTION
In the current version when you do `//cup config download` it errors out due to the f.write of the config expecting a string, but the download_file passes it a bytea, as can be seen here:
```
Aug 08 19:19:21 ip-172-31-13-195 python[29052]: ERROR    [default][skybaks.cup_manager.config] write() argument must be str, not bytes
Aug 08 19:19:21 ip-172-31-13-195 python[29052]: Traceback (most recent call last):
Aug 08 19:19:21 ip-172-31-13-195 python[29052]:   File "/home/ubuntu/.pyenv/versions/trackmania/lib/python3.7/site-packages/skybaks/cup_manager/config.py", line 221, in write_file_from_config_dir
```

Decoding the bytea to a string before it passes it to the write file method allows the download function to work